### PR TITLE
 🐛(content) add missing link on the footer

### DIFF
--- a/pages/_components/partials/footer.njk
+++ b/pages/_components/partials/footer.njk
@@ -18,7 +18,7 @@
                     </div>
                     <div>
                         <p class="text-center">
-                            <a href="https://info.france-universite-numerique.fr/mentions-legales/" target="_blank" class="link-dark text-decoration-underline small "> {{ 'Legal_mentions' | i18n }}</a>
+                            <a href="https://info.france-universite-numerique.fr/mentions-legales/" target="_blank" rel="noopener noreferrer" class="link-dark text-decoration-underline small "> {{ 'Legal_mentions' | i18n }}</a>
                         </p>
                     </div>
                 </div>

--- a/pages/_components/partials/footer.njk
+++ b/pages/_components/partials/footer.njk
@@ -18,7 +18,7 @@
                     </div>
                     <div>
                         <p class="text-center">
-                            <a href="" class="link-dark text-decoration-underline small "> {{ 'Legal_mentions' | i18n }}</a>
+                            <a href="https://info.france-universite-numerique.fr/mentions-legales/" target="_blank" class="link-dark text-decoration-underline small "> {{ 'Legal_mentions' | i18n }}</a>
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
The "Legal mentions" link was left empty on the footer. 
We now can add this one from the news site: https://info.france-universite-numerique.fr/mentions-legales/