### PR TITLE
Contact Link Replacement

### DIFF
--- a/pages/_components/partials/contact.njk
+++ b/pages/_components/partials/contact.njk
@@ -1,5 +1,5 @@
 <section id="contact" class="text-center">
     <h2 class="h1 fw-black mb-5">{{ 'Contact' | i18n }}</h2>
     <h3 class="h5 col-8 m-auto mb-5 mt-0 fw-light" style="max-width: 40rem;">{{ 'Contact_text' | i18n }} </h3>
-    <a href="https://www.fun-mooc.help/hc/fr/requests/new" class="btn mb-5 btn-info"><span class="text-white">{{ 'Contact_button' | i18n }}</span></a>
+    <a mailto:cellule-appui-contractualisation@fun-mooc.fr class="btn mb-5 btn-info"><span class="text-white">{{ 'Contact_button' | i18n }}</span></a>
 </section>


### PR DESCRIPTION
Our contract management team prefers to be contacted directly via email instead of using the contact form. As a result, the contact link on the website needs to be updated.